### PR TITLE
Исправить рендеринг Mermaid на GitHub Pages для раздела system design

### DIFF
--- a/assets/mermaid-init.js
+++ b/assets/mermaid-init.js
@@ -1,0 +1,57 @@
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+
+const SELECTOR = 'pre code.language-mermaid, pre code.lang-mermaid';
+
+function decodeHtmlEntities(input) {
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = input;
+  return textarea.value;
+}
+
+function convertMermaidCodeBlocks() {
+  const codeBlocks = Array.from(document.querySelectorAll(SELECTOR));
+
+  codeBlocks.forEach((codeBlock, index) => {
+    const pre = codeBlock.closest('pre');
+    if (!pre) {
+      return;
+    }
+
+    const source = decodeHtmlEntities(codeBlock.textContent || '');
+    const container = document.createElement('div');
+    container.className = 'mermaid';
+    container.id = `mermaid-diagram-${index + 1}`;
+    container.textContent = source.trim();
+
+    pre.replaceWith(container);
+  });
+
+  return codeBlocks.length;
+}
+
+function addFallbackNotice(error) {
+  console.error('Mermaid initialization failed:', error);
+}
+
+async function initMermaid() {
+  try {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: 'loose',
+      theme: 'default',
+    });
+
+    const diagramsCount = convertMermaidCodeBlocks();
+    if (diagramsCount > 0) {
+      await mermaid.run({ querySelector: '.mermaid' });
+    }
+  } catch (error) {
+    addFallbackNotice(error);
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initMermaid, { once: true });
+} else {
+  initMermaid();
+}

--- a/system design/01-основы-и-архитектурные-компромиссы.md
+++ b/system design/01-основы-и-архитектурные-компромиссы.md
@@ -1,4 +1,5 @@
 # Основы и архитектурные компромиссы
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 

--- a/system design/02-сетевое-взаимодействие-и-api.md
+++ b/system design/02-сетевое-взаимодействие-и-api.md
@@ -1,4 +1,5 @@
 # Сетевое взаимодействие и API
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 

--- a/system design/03-хранение-данных-и-выбор-базы.md
+++ b/system design/03-хранение-данных-и-выбор-базы.md
@@ -1,4 +1,5 @@
 # Хранение данных и выбор базы
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 

--- a/system design/04-кэширование.md
+++ b/system design/04-кэширование.md
@@ -1,4 +1,5 @@
 # Кэширование
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 

--- a/system design/05-асинхронность-и-событийные-системы.md
+++ b/system design/05-асинхронность-и-событийные-системы.md
@@ -1,4 +1,5 @@
 # Асинхронность и событийные системы
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 

--- a/system design/06-масштабирование-надежность-и-отказоустойчивость.md
+++ b/system design/06-масштабирование-надежность-и-отказоустойчивость.md
@@ -1,4 +1,5 @@
 # Масштабирование, надёжность и отказоустойчивость
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 

--- a/system design/07-микросервисы-границы-и-декомпозиция.md
+++ b/system design/07-микросервисы-границы-и-декомпозиция.md
@@ -1,4 +1,5 @@
 # Микросервисы, границы и декомпозиция
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 

--- a/system design/08-наблюдаемость-безопасность-и-эксплуатация.md
+++ b/system design/08-наблюдаемость-безопасность-и-эксплуатация.md
@@ -1,4 +1,5 @@
 # Наблюдаемость, безопасность и эксплуатация
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 

--- a/system design/10-multi-region-и-geo-distributed-системы.md
+++ b/system design/10-multi-region-и-geo-distributed-системы.md
@@ -1,4 +1,5 @@
 # Multi-region и geo-distributed системы
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 

--- a/system design/11-cdc-event-sourcing-и-materialized-views.md
+++ b/system design/11-cdc-event-sourcing-и-materialized-views.md
@@ -1,4 +1,5 @@
 # CDC, event sourcing и materialized views
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 

--- a/system design/12-эволюция-системы-и-миграции-без-простоя.md
+++ b/system design/12-эволюция-системы-и-миграции-без-простоя.md
@@ -1,4 +1,5 @@
 # Эволюция системы и миграции без простоя
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 

--- a/system design/13-consensus-и-распределенная-координация.md
+++ b/system design/13-consensus-и-распределенная-координация.md
@@ -1,4 +1,5 @@
 # Consensus и распределённая координация
+<script type="module" src="../assets/mermaid-init.js"></script>
 
 ## Содержание
 


### PR DESCRIPTION
### Motivation

- На страницах раздела `system design` fenced-блоки Mermaid рендерятся как обычный код в GitHub Pages вместо диаграмм, что ухудшает читаемость материалов.
- Нужно клиентское решение, которое в браузере на странице GitHub Pages найдёт такие блоки и запустит Mermaid для генерации SVG.

### Description

- Добавлен клиентский ESM-инициализатор `assets/mermaid-init.js`, который импортирует Mermaid с CDN, конвертирует `pre code.language-mermaid` в `<div class="mermaid">` и вызывает `mermaid.run` для рендеринга.
- Во все Markdown-страницы раздела `system design`, содержащие Mermaid-диаграммы, добавлено подключение скрипта сразу после заголовка: `<script type="module" src="../assets/mermaid-init.js"></script>`.
- Скрипт декодирует HTML-сущности внутри код-блоков, назначает уникальные id диаграмм и использует `securityLevel: 'loose'` для совместимости с GitHub Pages.

### Testing

- Выполнена проверка синтаксиса скрипта через `node --check assets/mermaid-init.js`, результат — успешно.
- Подтверждено присутствие подключения скрипта во всех целевых файлов через поиск (`rg -n "mermaid-init\.js" "system design"/*.md`).
- Попытка автоматически провалидировать рендеринг через Playwright не выполнена из-за ограничения окружения (установка `playwright` блокируется 403 от `registry.npmjs.org`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca70593728833188a45c5ade42a49e)