### PR TITLE
Добавить ссылку на «Synchronized» в секцию Multithreading в java/README.md

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -32,6 +32,7 @@
   - [Шаблоны и практические приёмы](multithreading/07-patterns.md)
   - [Практические упражнения](multithreading/08-exercises.md)
   - [Вопросы на собеседовании](multithreading/09-interview-questions.md)
+  - [Synchronized: теория и практика](multithreading/10-synchronized.md)
 
 → [Перейти к материалам по Multithreading](multithreading/README.md)
 


### PR DESCRIPTION
### Motivation
- Добавить в оглавление раздела Multithreading ссылку на существующий файл `multithreading/10-synchronized.md`, чтобы список в `java/README.md` полностью соответствовал содержимому каталога и нумерации файлов.

### Description
- Обновлён `java/README.md`: в разделе `### [Multithreading](multithreading/README.md)` добавлен пункт `- [Synchronized: теория и практика](multithreading/10-synchronized.md)`, порядок пунктов теперь соответствует файловой нумерации `01`–`10` в `java/multithreading/`.

### Testing
- Подтверждена наличность файла и содержимого каталога командой `ls -1 java/multithreading` — `10-synchronized.md` присутствует и нумерация корректна (успешно).
- Проверено отображение и позиция нового пункта в README командами `sed -n '18,55p' java/README.md` и `nl -ba java/README.md | sed -n '24,46p'` — новый пункт виден в нужной позиции (успешно).
- Проверено, что изменился только `java/README.md` при проверке рабочего дерева — изменений в других файлах не обнаружено (успешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4c2504648331a6caf118fb73ce3a)