### PR TITLE
Migrate Java EE imports to Jakarta (JPA/Validation/Servlet/JMS) and clarify ActiveMQ legacy vs Artemis

### DIFF
--- a/java/04-hibernate.md
+++ b/java/04-hibernate.md
@@ -925,8 +925,12 @@ Product product = em.find(Product.class, 1L, LockModeType.PESSIMISTIC_READ);
 
 // С таймаутом
 em.find(Product.class, 1L, LockModeType.PESSIMISTIC_WRITE, 
-    Collections.singletonMap("javax.persistence.lock.timeout", 5000));
+    Collections.singletonMap("jakarta.persistence.lock.timeout", 5000));
 ```
+
+> Для Jakarta Persistence 3.0+ актуальный стандартный hint — `jakarta.persistence.lock.timeout`.
+> Hibernate 6 также распознаёт старый `javax.persistence.lock.timeout` для миграционной совместимости,
+> но это legacy-ключ JPA 2.2 (Hibernate 5.x / Spring Boot 2.x), на который нельзя полагаться с другим провайдером.
 
 **Типы пессимистичных блокировок:**
 - `PESSIMISTIC_READ` — разделяемая блокировка (другие могут читать)
@@ -986,7 +990,7 @@ public class User {
 // Использование
 EntityGraph<?> graph = em.getEntityGraph("User.orders");
 Map<String, Object> hints = new HashMap<>();
-hints.put("javax.persistence.fetchgraph", graph);
+hints.put("jakarta.persistence.fetchgraph", graph);
 User user = em.find(User.class, 1L, hints);
 ```
 
@@ -996,9 +1000,13 @@ EntityGraph<User> graph = em.createEntityGraph(User.class);
 graph.addAttributeNodes("orders", "profile");
 
 Map<String, Object> hints = new HashMap<>();
-hints.put("javax.persistence.fetchgraph", graph);
+hints.put("jakarta.persistence.fetchgraph", graph);
 User user = em.find(User.class, 1L, hints);
 ```
+
+> В Jakarta Persistence 3.0+ стандартный ключ графа — `jakarta.persistence.fetchgraph`.
+> Hibernate 6 сохраняет распознавание legacy-ключа `javax.persistence.fetchgraph`, использовавшегося в JPA 2.2
+> и Hibernate 5.x, однако переносимый современный код должен передавать ключ с префиксом `jakarta`.
 
 ### Статистика Hibernate
 

--- a/java/java-core/06-data-io.md
+++ b/java/java-core/06-data-io.md
@@ -41,7 +41,7 @@
 ## Работа с сетевыми данными
 - **HTTP**: `HttpClient` (Java 11) поддерживает синхронные и асинхронные запросы, HTTP/2, WebSocket.
 - **Sockets**: `ServerSocket`, `Socket` для блокирующих сценариев; `SocketChannel` — неблокирующий.
-- **gRPC/REST**: используйте DTO, валидацию (`javax.validation`) и логирование запросов.
+- **gRPC/REST**: используйте DTO, валидацию (`jakarta.validation`, baseline Spring Boot 3) и логирование запросов.
 
 ## Производительность и безопасность
 - Используйте `BufferedInputStream`/`BufferedOutputStream` для уменьшения количества системных вызовов.

--- a/очереди/activemq/01-основы-и-архитектура.md
+++ b/очереди/activemq/01-основы-и-архитектура.md
@@ -38,6 +38,10 @@ Apache ActiveMQ — это высокопроизводительный брок
 
 JMS — это стандартный API Java для обмена сообщениями между приложениями. Определяет:
 
+> **Современный baseline:** Spring Boot 3 и Jakarta Messaging 3.x используют пакет `jakarta.jms`.
+> Для новых проектов выбирайте ActiveMQ Artemis с Jakarta-клиентом. ActiveMQ Classic 5.x и
+> Spring Boot 2.x относятся к legacy-baseline с API `javax.jms`.
+
 - **Провайдер (Provider)**: Реализация JMS (ActiveMQ, RabbitMQ, IBM MQ и др.)
 - **Клиент (Client)**: Приложение, отправляющее или получающее сообщения
 - **Сообщение (Message)**: Объект данных, пересылаемый между клиентами
@@ -303,11 +307,11 @@ try {
 
 ## Пример использования
 
-### Полный пример Producer
+### Современный Producer: Artemis и Jakarta Messaging
 
 ```java
-import org.apache.activemq.ActiveMQConnectionFactory;
-import javax.jms.*;
+import jakarta.jms.*;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 
 public class OrderProducer {
     public static void main(String[] args) throws JMSException {
@@ -349,11 +353,11 @@ public class OrderProducer {
 }
 ```
 
-### Полный пример Consumer
+### Современный Consumer: Artemis и Jakarta Messaging
 
 ```java
-import org.apache.activemq.ActiveMQConnectionFactory;
-import javax.jms.*;
+import jakarta.jms.*;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 
 public class OrderConsumer {
     public static void main(String[] args) throws JMSException, InterruptedException {
@@ -403,6 +407,19 @@ public class OrderConsumer {
         connection.close();
     }
 }
+```
+
+### Legacy: ActiveMQ Classic 5.x и JMS 1.1/2.0
+
+> **Legacy-блок:** этот namespace нужен для ActiveMQ Classic 5.x с обычным
+> `activemq-client` и для Spring Boot 2.x. Не смешивайте типы `javax.jms` и `jakarta.jms`
+> в одном classpath: это разные, бинарно несовместимые API.
+
+```java
+import javax.jms.*;
+import org.apache.activemq.ActiveMQConnectionFactory;
+
+// Остальной JMS-код аналогичен, но должен собираться с legacy-зависимостями.
 ```
 
 ### Конфигурация через Spring

--- a/паттерны проектирования/поведенческие/08-strategy.md
+++ b/паттерны проектирования/поведенческие/08-strategy.md
@@ -420,11 +420,16 @@ names.sort((s1, s2) -> s1.compareTo(s2));
 names.sort(Comparator.comparingInt(String::length));
 ```
 
-### Из javax.servlet
+### Из Jakarta Servlet
 
-`Filter` в Servlet API — это Strategy для обработки HTTP-запросов:
+`jakarta.servlet.Filter` в Servlet API 5.0+ (Spring Boot 3) — это Strategy для обработки HTTP-запросов:
 
 ```java
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
 public class AuthenticationFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, 
@@ -617,7 +622,7 @@ List<Integer> greaterThanThree = numbers.stream()
 *Ответ:* 
 - `java.util.Comparator` — стратегия сравнения объектов
 - `java.io.FileFilter` — стратегия фильтрации файлов
-- `javax.servlet.Filter` — стратегия обработки HTTP-запросов
+- `jakarta.servlet.Filter` — стратегия обработки HTTP-запросов (Servlet 5.0+, Spring Boot 3)
 - `java.awt.LayoutManager` — стратегия размещения компонентов
 
 **4. В чём разница между Strategy и State?**

--- a/паттерны проектирования/структурные/05-facade.md
+++ b/паттерны проектирования/структурные/05-facade.md
@@ -1095,7 +1095,7 @@ class User {
 ### EntityManager (JPA)
 
 ```java
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Service
 public class JpaFacadeExample {
@@ -1601,4 +1601,3 @@ public class ApiGatewayFacade {
 ---
 
 [← Назад к разделу Структурные паттерны](README.md)
-


### PR DESCRIPTION
### Motivation

- Привести примеры к современному baseline Spring Boot 3 / Hibernate 6, обновив Java EE API (`javax.*`) на соответствующие Jakarta-пакеты там, где это требуется для переносимости.
- Сохранить и явно пометить legacy-контент (ActiveMQ Classic, старые JPA-хинты) вместо удаления, чтобы читатель видел совместимость и ограничения.
- Не менять Java SE API (`javax.swing`, `javax.xml`, `javax.crypto`) и сохранить их в исходном виде как допустимые исключения.

### Description

- Заменены импорты и упоминания Bean Validation на `jakarta.validation` в `java/java-core/06-data-io.md` и помечен новый baseline Spring Boot 3.
- Обновлены JPA-примеры и EntityManager-импорты на `jakarta.persistence` в `паттерны проектирования/структурные/05-facade.md` и соответствующие места в `java/04-hibernate.md` с заменой строковых hint-ключей на `jakarta.persistence.lock.timeout` и `jakarta.persistence.fetchgraph` и добавлен текст о миграционной совместимости (Hibernate 6 распознаёт старые `javax.*` как legacy).
- Обновлён раздел про Servlet/Filter в `паттерны проектирования/поведенческие/08-strategy.md` на `jakarta.servlet.Filter` с примером импорта для Servlet API 5.0+ (Spring Boot 3).
- Раздел ActiveMQ `очереди/activemq/01-основы-и-архитектура.md` переработан: добавлен современный блок по ActiveMQ Artemis + `jakarta.jms` и явный legacy-блок для ActiveMQ Classic 5.x с `javax.jms` и пояснениями о несовместимости `javax.jms` vs `jakarta.jms` в одном classpath.
- Сохранены без изменений упоминания Java SE API (`javax.swing`, `javax.xml`, `javax.crypto`) в соответствующих файлах.

### Testing

- Запущена проверка поиска `rg -n 'javax\.' java 'тестирование' 'очереди' 'паттерны проектирования'` и подтверждено, что оставшиеся совпадения относятся к Java SE API или к явно помеченным legacy-блокам.
- Выполнены `git diff --check`, `git diff --stat` и просмотр diff для контроля формата и изменений; результаты не выявили проблем синтаксиса diff.
- Проверен рабочий статус репозитория через `git status --short` и просмотр изменённых файлов для ревью (изменения присутствуют в целевых файлах).
- Попытка вызвать локальный MCP-инструмент `make_pr` в окружении завершилась с ошибкой из-за отсутствующей/несовместимой локальной установки MCP, поэтому автоматическая публикация PR через этот вспомогательный инструмент не была выполнена.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71a45b08748331afb0d980ef5b9908)